### PR TITLE
Added Download GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# gitginore template for creating Snap packages
+# website: https://snapcraft.io/
+
+parts/
+prime/
+stage/
+*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/download-launcher.py
+++ b/scripts/download-launcher.py
@@ -1,18 +1,157 @@
 #!/usr/bin/env python3
 
+import gi  # in package python3-gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, GLib
+import requests
+import math
+
+from threading import Thread
+import hashlib
 import os.path
-from urllib.request import urlretrieve 
 import subprocess
-import os
-import re
+
+DOWNLOAD_LINK = "https://launcher.mojang.com/download/Minecraft.tar.gz"
+DOWNLOAD_FILE = "Minecraft.tar.gz"
+RESULT_PATH = "minecraft-launcher"
 
 
-def main():
-    urlretrieve("https://launcher.mojang.com/download/Minecraft.tar.gz", "minecraft-launcher.tar.gz")
-    
-    subprocess.call(['tar','-xzf','minecraft-launcher.tar.gz'])
-    
-    subprocess.call(['rm','-rf','minecraft-launcher.tar.gz'])
-    
-main()
+def convert_size(size_bytes):
+   if size_bytes == 0:
+       return "0B"
+   size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+   i = int(math.floor(math.log(size_bytes, 1024)))
+   p = math.pow(1024, i)
+   s = round(size_bytes / p, 2)
+   return "{}{}".format(s, size_name[i])
 
+
+class SnapUIWindow(Gtk.Window):
+
+    def __init__(self):
+        Gtk.Window.__init__(self, title="Downloading Minecraft Launcher")
+        self.set_border_width(10)
+        # self.set_default_size(640, 480)
+        self.set_position(Gtk.WindowPosition.CENTER)
+
+        hb = Gtk.HeaderBar()
+        hb.set_show_close_button(True)
+        hb.props.title = "Downloading Minecraft Launcher"
+        self.set_titlebar(hb)
+
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        self.add(vbox)
+
+        self.infolabel = Gtk.Label(justify=Gtk.Justification.CENTER)
+        vbox.pack_start(self.infolabel, False, True, 10)
+
+        self.progressbar = Gtk.ProgressBar()
+        self.progressbar.set_show_text(True)
+        vbox.pack_start(self.progressbar, False, True, 0)
+
+        self.retry_button = Gtk.Button.new_with_mnemonic("Retry Download")
+        self.retry_button.connect("clicked", self.retry_onclick)
+        vbox.pack_end(self.retry_button, False, True, 00)
+
+    def retry_onclick(self, button):
+        self.start_download()
+
+    def start_download(self):
+        self.infolabel.set_text("Downloading the latest Minecraft: Java Edition launcher.")
+        self.progressbar.set_text(DOWNLOAD_LINK)
+        self.progressbar.show()
+        self.retry_button.hide()
+
+        thread = Thread(target=self.download_thread)
+        thread.daemon = True
+        thread.start()
+
+    def download_error(self, e):
+        self.infolabel.set_text("Download failed!\nPlease check your internet connection and retry.")
+        self.progressbar.set_text(str(e))
+        self.progressbar.hide()
+        self.retry_button.show()
+
+    def download_thread(self):
+        from pathlib import Path
+        import requests
+
+        try:
+            r = requests.get(DOWNLOAD_LINK, allow_redirects=True, timeout=10, stream=True)
+            r.raise_for_status()
+
+            totalsize = int(r.headers.get('content-length', 0))
+            blocksize = 2048
+            blocknum = 0
+
+            with open(DOWNLOAD_FILE, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=blocksize):
+                    if chunk:
+                        f.write(chunk)
+                        f.flush()
+                    self.report_progress(blocknum, blocksize, totalsize)
+                    blocknum = blocknum + 1
+
+        except requests.exceptions.RequestException as e:
+            # Ask the main thread to execute this code.
+            GLib.idle_add(self.download_error, e)
+            return
+
+        subprocess.call(['tar','-xzf', DOWNLOAD_FILE])
+        subprocess.call(['rm','-f', DOWNLOAD_FILE])
+
+        with open('Minecraft-Launcher-Last-Modified', 'w+') as f:
+            f.write(r.headers.get("Last-Modified"))
+
+        Gtk.main_quit()
+
+    def report_progress(self, blocknum, blocksize, totalsize):
+        p = round((blocknum * blocksize) / totalsize, 2)
+        # Ask the main thread to execute this code. Because GTK isn't
+        # thread safe, you cannot execute `set_fraction` in another thread.
+        #   https://pygobject.readthedocs.io/en/latest/guide/threading.html
+        GLib.idle_add(self.progressbar.set_fraction, p)
+        GLib.idle_add(self.progressbar.set_text, "{}/{}".format(convert_size(blocknum*blocksize), convert_size(totalsize)))
+
+
+def requires_update():
+    """ requires_update returns true
+         * If no launcher is present
+         * If a launcher is present but a newer version is available online.
+    """
+    if not os.path.isdir(RESULT_PATH):
+        # Launcher isn't present
+        return True
+
+    try:
+        with open('Minecraft-Launcher-Last-Modified', 'r') as f:
+            last_modified = f.read()
+    except FileNotFoundError:
+        last_modified = "NEVER"
+    try:
+        response = requests.head(DOWNLOAD_LINK)
+        if response.headers.get("Last-Modified") != last_modified:
+            # New Launcher Available
+            return True
+        else:
+            # Launcher is already latest
+            return False            
+    except requests.exceptions.ConnectionError:
+        # No network available
+        return False
+
+# Only start the GUI if we actually need to download the launcher.
+if requires_update():
+    win = SnapUIWindow()
+    win.connect("delete-event", Gtk.main_quit)
+    win.show_all()
+    win.start_download()
+    Gtk.main()
+
+# This script returns exit code
+#   0 (success) if launcher is present or
+#   1 (fail)    if not.
+if os.path.isdir(RESULT_PATH):
+    exit(0)
+else:
+    exit(1)

--- a/scripts/launch
+++ b/scripts/launch
@@ -14,11 +14,6 @@ set -e
 	$SNAP/download-launcher.py
 )
 
-#java \
-	#-Duser.home=$HOME/appdata \
-	#-jar $SNAP_USER_DATA/Minecraft.jar
-	
-# Adding method to use new launcher
 set -e
 (
 	$SNAP_USER_DATA/minecraft-launcher/./minecraft-launcher

--- a/snap/gui/mc-installer.desktop
+++ b/snap/gui/mc-installer.desktop
@@ -1,11 +1,12 @@
 [Desktop Entry]
 Encoding=UTF-8
 Name=Minecraft
-GenericName=Minecraft Launcher
-Comment=Installs Minecraft and launches it automatically
+GenericName=Minecraft Installer
+Comment=A simple installer for Minecraft - Java Edition
 Exec=mc-installer
 Icon=${SNAP}/meta/gui/mcinstaller.png
 Terminal=false
 Type=Application
 StartupNotify=false
 Categories=Application;Game
+Keywords=mc-installer;

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,10 +1,12 @@
 name: mc-installer
-version: 4.1.1
+title: Minecraft Installer
+version: "4.2"
 summary: A simple installer for Minecraft - Java Edition
 description: | 
   A simple installer for Minecraft - Java Edition. 
-  You must have an internet connection to use this snap as it downloads and installs the newest version each time.
+license: MIT
 
+base: core18
 grade: stable
 confinement: strict
 
@@ -22,38 +24,61 @@ apps:
       - desktop-legacy
       - browser-support
       - home
+    environment:
+      PYTHONPATH: $SNAP/gnome-platform/usr/lib/python3/dist-packages
 
 parts:
   launcher:
     plugin: dump
     source: scripts
-    after: [desktop-gtk3]
+    after: [desktop-gnome-platform]
 
   game:
     plugin: nil
-    build-packages:
-      - ca-certificates
-      - ca-certificates-java
-      - openjdk-8-jre-headless
     stage-packages:
       - libgl1-mesa-dri
-      - libpulse0
-      - yad
-      - wget
-      - libxext6
-      - libxrender1
-      - libxtst6
-      - libxi6
       - libswt-gtk-3-java
-      - libwebkit2gtk-3.0-25
       - x11-xserver-utils
-      - python3-gi
-      - python3-gi-cairo
-      - python3-cairo
       - python3-requests
-      - gir1.2-gtk-3.0
       - openjdk-8-jre-headless
       - libxss1
       - libgconf2-4
-      - libasound2
       - libcurl3
+
+  # This part installs the `desktop-launch` script which initialises desktop
+  # features such as fonts, themes and the XDG environment.
+  #
+  # It is copied straight from the snapcraft desktop helpers project. Please
+  # periodically check the source for updates and copy the changes.
+  #    https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+  #
+  desktop-gnome-platform:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - gcc
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
+
+plugs:
+  # GTK libraries
+  gnome-3-28-1804:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-3-28-1804
+  # Common GTK themes
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -27,7 +27,7 @@ parts:
   launcher:
     plugin: dump
     source: scripts
-    after: [desktop-qt5]
+    after: [desktop-gtk3]
 
   game:
     plugin: nil
@@ -50,6 +50,7 @@ parts:
       - python3-gi
       - python3-gi-cairo
       - python3-cairo
+      - python3-requests
       - gir1.2-gtk-3.0
       - openjdk-8-jre-headless
       - libxss1


### PR DESCRIPTION
Some people complain in reviews that the snap isn't working. This is probably because they had a slow or no internet connection. For that reason I added the following features:

* The script now only tries to download the launcher in the following two occasions.
   1. When there is no Launcher present
   2. When a Launcher is present, there is an internet connection and a new version of the launcher is available online.
* The script now shows a download GUI with a progress bar and a retry button in case the download failed.
* The download is now done using the python `requests` library, which handles unreliable connections and network errors a lot better.

I also added a `.gitignore` file and a license. The info of the snap says it's MIT licensed, so I chose that license. Let me know if you prefer another license.

*Note: for some reason, the GUI doesn't work when you start it using the commandline. This seems to be the case for other GUI snaps too.*