### PR TITLE
Limit arch to amd64 since that is the only one supported by the launcher

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mc-installer
 title: Minecraft Installer
-version: "6.1"
+version: "latest"
 summary: A simple installer for Minecraft - Java Edition
 description: | 
   A simple installer for Minecraft - Java Edition. 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,6 +10,9 @@ base: core18
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+
 apps:
   mc-installer:
     extensions:


### PR DESCRIPTION
Given that the launcher contains an amd64 binary, this snap only supports the amd64 arch. This commit makes it so the build system only builds on amd64 anymore. This should stop all the failed builds every time the snap is rebuilt.

I also changed the version to "latest" to make it more clear to users that this snap will install the latest minecraft launcher version. You can still manually trigger a rebuild by clicking the "Trigger new build" button in the builds section of the snapcraft store: https://snapcraft.io/mc-installer/builds Is this OK with you? I can revert the version change if you'd like to keep using a numbered version.