### PR TITLE
fixed archive.org last-modified

### DIFF
--- a/scripts/download-launcher.py
+++ b/scripts/download-launcher.py
@@ -103,7 +103,7 @@ class SnapUIWindow(Gtk.Window):
         subprocess.call(['rm','-f', DOWNLOAD_FILE])
 
         with open('Minecraft-Launcher-Last-Modified', 'w+') as f:
-            f.write(r.headers.get("Last-Modified"))
+            f.write(r.headers.get("Last-Modified", DOWNLOAD_LINK))
 
         Gtk.main_quit()
 
@@ -131,8 +131,8 @@ def requires_update():
     except FileNotFoundError:
         last_modified = "NEVER"
     try:
-        response = requests.head(DOWNLOAD_LINK)
-        if response.headers.get("Last-Modified") != last_modified:
+        response = requests.head(DOWNLOAD_LINK, allow_redirects=True, timeout=10)
+        if response.headers.get("Last-Modified", DOWNLOAD_LINK) != last_modified:
             # New Launcher Available
             return True
         else:


### PR DESCRIPTION
Turns out, the issue was in our script, not in archive.org. It provides the correct headers but it has an HTTP redirect. The code which checks if an updated version is available didn't follow the redirect but the code to download the file did.

For good measure, I also added a smarter fallback when the server doesn't support the last-modified http header; only download it again if the url changed.