### PR TITLE
Default to using NVIDIA card on Optimus laptops

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,6 +41,8 @@ apps:
     environment:
       PYTHONPATH: $SNAP_DESKTOP_RUNTIME/usr/lib/python3.8/site-packages
       JAVA_HOME: $SNAP/usr/lib/jvm/java-16-openjdk-amd64/
+      __NV_PRIME_RENDER_OFFLOAD: 1
+      __GLX_VENDOR_LIBRARY_NAME: nvidia
 
 parts:
   launcher:


### PR DESCRIPTION
Without these 2 environment variables, Minecraft will default to using Intel UHD graphics