### PR TITLE
Removing pulse audio plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,7 +35,6 @@ apps:
       - network
       - opengl
       - audio-playback
-      - pulseaudio
       - browser-support
       - home
       - dot-minecraft      


### PR DESCRIPTION
I was testing this on my own machine, and the audio-playback plug is enough for Minecraft to play audio. The pulseaudio plug will allow it to both play and record audio, and it really got no reason to do so. Thus, I think its better to remove this unnecessary permission for it.