### PR TITLE
Added logs app to view minecraft logs

### DIFF
--- a/scripts/logs
+++ b/scripts/logs
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ ! -d $SNAP_USER_COMMON/.minecraft/logs ];
+then
+	mkdir -p $SNAP_USER_COMMON/.minecraft/logs
+fi
+
+xdg-open $SNAP_USER_COMMON/.minecraft/logs

--- a/snap/gui/mc-installer.desktop
+++ b/snap/gui/mc-installer.desktop
@@ -10,3 +10,8 @@ Type=Application
 StartupNotify=false
 Categories=Application;Game
 Keywords=mc-installer;
+Actions=Logs;
+
+[Desktop Action Logs]
+Name=Logs
+Exec=mc-installer.logs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,14 @@ apps:
       JAVA_HOME: $SNAP/usr/lib/jvm/java-17-openjdk-amd64/
       __NV_PRIME_RENDER_OFFLOAD: 1
       __GLX_VENDOR_LIBRARY_NAME: nvidia      
+      HOME: $SNAP_USER_COMMON
+  logs:
+    extensions:
+      - gnome
+    command: logs
+    environment:
+      HOME: $SNAP_USER_COMMON
+
 parts:
   launcher:
     plugin: dump


### PR DESCRIPTION
Added logs app to view minecraft logs.  This is available as a right click action on the icon to view the directory where the latest.log exists.  Also utilize SNAP_USER_COMMON to store data that shouldn't actually be versioned with the snap.
